### PR TITLE
Update Fuel Flow Scalar

### DIFF
--- a/SimObjects/Airplanes/Asobo_B747_8i/engines.cfg
+++ b/SimObjects/Airplanes/Asobo_B747_8i/engines.cfg
@@ -4,7 +4,7 @@ minor = 0
 
 [GENERALENGINEDATA]
 engine_type = 1 ; 0=Piston, 1=Jet, 2=None, 3=Helo-Turbine, 4=Rocket, 5=Turboprop
-fuel_flow_scalar = 0.8 ; Fuel flow scalar
+fuel_flow_scalar = 1.276 ; Fuel flow scalar
 min_throttle_limit = -0.25 ; Minimum percent throttle.  Generally negative for turbine reverser
 master_ignition_switch = 0
 starter_type = 2 ; 0=Electric, 1=Manual, 2=Bleed Air


### PR DESCRIPTION
Fuel scalar set to 1.276

"On short-haul flights using this scalar, it is guaranteed you are going to burn up to a few more thousand pounds than planned, however flying long-haul, it will be a few thousand or tens of thousands over. It's a compromise but lowering the fuel scalar so short-haul flights are more accurate will mean that 3,000 pound difference on a short-haul will actually be potentially be several tens of thousands of pounds overweight when landing.

I currently think 1.276 is the best of both worlds for the mean time. You're not going to run out of fuel on a short haul, and you're not going to be overweight with landing on a long-haul."